### PR TITLE
LRQA 70110

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -284,6 +284,7 @@
     #    dxp/apps/document-library-opener,\
     #    dxp/apps/enterprise-product-notification,\
     #    dxp/apps/frontend-theme,\
+    #    dxp/apps/lcs,\
     #    dxp/apps/multi-factor-authentication,\
     #    dxp/apps/portal,\
     #    dxp/apps/portal-reports-engine-console,\

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -1,5 +1,24 @@
 definition {
 
+	macro assertContent {
+		if (!(isSet(index))) {
+			var index = "1";
+		}
+
+		AssertTextEquals(
+			key_fieldLabel = "${linkToPageFieldLabel}",
+			key_index = "${index}",
+			locator1 = "DataEngineRenderer#SELECTOR_INPUT_INDEXED",
+			value1 = "${linkToPageContent}");
+	}
+
+	macro assertContentInLinktoPageField {
+		DERenderer.assertContent(
+			index = "${index}",
+			linkToPageContent = "${linkToPageContent}",
+			linkToPageFieldLabel = "${linkToPageFieldLabel}");
+	}
+
 	macro assertDataInColorField {
 		if (!(isSet(index))) {
 			var index = "1";
@@ -171,21 +190,11 @@ definition {
 			locator1 = "DataEngineRenderer#IMAGE_PICKER_PREVIEW_INDEXED");
 	}
 
-	macro assertMultipleSelectionOptionIsUnchecked {
-		if (!(isSet(fieldIndex))) {
-			var fieldIndex = "1";
-		}
-
-		if (!(isSet(optionIndex))) {
-			var optionIndex = "1";
-		}
-
-		AssertNotChecked.assertNotCheckedNotVisible(
-			fieldIndex = "${fieldIndex}",
-			key_fieldLabel = "${fieldLabel}",
-			key_optionValue = "${optionValue}",
-			locator1 = "DataEngineRenderer#MULTIPLE_SELECTION_OPTION_INDEXED",
-			optionIndex = "${optionIndex}");
+	macro assertLinktoPageIsClear {
+		DERenderer.assertContent(
+			index = "${index}",
+			linkToPageContent = "",
+			linkToPageFieldLabel = "${linkToPageFieldLabel}");
 	}
 
 	macro assertUploadNotPresent {
@@ -357,6 +366,31 @@ definition {
 				locator1 = "DataEngineRenderer#IMAGE_DESCRIPTION_INDEXED",
 				value1 = "${imageDescription}");
 		}
+	}
+
+	macro inputDataInLinkToPageField {
+		if (!(isSet(index))) {
+			var index = "1";
+		}
+
+		WaitForLiferayEvent.initializeLiferayEventLog();
+
+		Click(
+			key_fieldLabel = "${linkToPageFieldLabel}",
+			key_index = "${index}",
+			key_text = "Select",
+			locator1 = "DataEngineRenderer#BUTTON_LABEL_INDEXED");
+
+		SelectFrame(locator1 = "IFrame#MODAL_BODY");
+
+		Portlet.expandTree();
+
+		AssertClick.assertPartialTextClickAt(
+			key_nodeName = "${linkToPageContent}",
+			locator1 = "Treeview#NODE_UNSELECTED",
+			value1 = "${linkToPageContent}");
+
+		SelectFrameTop();
 	}
 
 	macro inputDataInMultipleSelectionField {

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -172,12 +172,29 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "4"
 	test CanNotPublishBlankRequiredField {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldLabel = "Link to Page",
+			fieldName = "Link to Page");
+
+		DataEngine.editFieldRequired(fieldFieldLabel = "Link to Page");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		Button.clickPublish();
+
+		FormViewBuilder.validateObjectLabelOptionTextIsShown(text = "This field is required.");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -81,12 +81,45 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "5"
 	test CanClearInput {
+		JSONLayout.addPublicLayout(
+			groupName = "Test Site Name",
+			layoutName = "Test Page Name");
 
-		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DEBuilder.addField(
+			fieldLabel = "Link to Page",
+			fieldName = "Link to Page");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.inputDataInLinkToPageField(
+			linkToPageContent = "Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.clearDataOnField(fieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertLinktoPageNotPresent(
+			linkToPageContent = "Public Pages > Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
 	}
 
 	@description = "This is a test for LRQA-68680. This test verifies that Label and Help text can be edited."

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -198,12 +198,41 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "4"
 	test CanRemoveDuplicatedField {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldLabel = "Link to Page",
+			fieldName = "Link to Page");
+
+		DataEngine.toggleFieldRepeatable(fieldFieldLabel = "Link to Page");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DataEngine.addRepeatableField(fieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.removeRepeatableField(fieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DEBuilder.assertFieldNotPresent(
+			fieldLabel = "Link to Page",
+			index = "2");
 	}
 
 	@description = "This is a test for LRQA-68680. This test verifies that Default Searchable property is 'Disable' when System Setting is left unchecked"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -80,6 +80,15 @@ definition {
 			fieldName = "Link to Page");
 	}
 
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanClearInput {
+
+		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+
+	}
+
 	@description = "This is a test for LRQA-68680. This test verifies that Label and Help text can be edited."
 	@priority = "5"
 	test CanEditLabelAndHelpText {
@@ -115,6 +124,42 @@ definition {
 			fieldFieldLabel = "Link to Page Edited",
 			fieldHelp = "Help Text Edited",
 			fieldName = "Link to Page");
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanInputDataOnDuplicatedField {
+
+		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanInputLink {
+
+		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanNotPublishBlankRequiredField {
+
+		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanRemoveDuplicatedField {
+
+		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+
 	}
 
 	@description = "This is a test for LRQA-68680. This test verifies that Default Searchable property is 'Disable' when System Setting is left unchecked"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -136,12 +136,39 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "5"
 	test CanInputLink {
+		JSONLayout.addPublicLayout(
+			groupName = "Test Site Name",
+			layoutName = "Test Page Name");
 
-		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DEBuilder.addField(
+			fieldLabel = "Link to Page",
+			fieldName = "Link to Page");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.inputDataInLinkToPageField(
+			linkToPageContent = "Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertContentInLinktoPageField(
+			linkToPageContent = "Public Pages > Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DELinkToPageField.testcase
@@ -80,7 +80,7 @@ definition {
 			fieldName = "Link to Page");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-70110. This test verifies that is possible to clear the link"
 	@priority = "5"
 	test CanClearInput {
 		JSONLayout.addPublicLayout(
@@ -117,9 +117,7 @@ definition {
 
 		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
 
-		DERenderer.assertLinktoPageNotPresent(
-			linkToPageContent = "Public Pages > Test Page Name",
-			linkToPageFieldLabel = "Link to Page");
+		DERenderer.assertLinktoPageIsClear(linkToPageFieldLabel = "Link to Page");
 	}
 
 	@description = "This is a test for LRQA-68680. This test verifies that Label and Help text can be edited."
@@ -159,16 +157,59 @@ definition {
 			fieldName = "Link to Page");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "This is a test for LRQA-70110. This test verifies that upon duplicating a repeatable field, inputted data on both fields persists"
 	@priority = "5"
 	test CanInputDataOnDuplicatedField {
+		JSONLayout.addPublicLayout(
+			groupName = "Test Site Name",
+			layoutName = "Test Page Name");
 
-		// TODO LRQA-70110	Refactor of Renderer Link to Page Field
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DEBuilder.addField(
+			fieldLabel = "Link to Page",
+			fieldName = "Link to Page");
+
+		DataEngine.toggleFieldRepeatable(fieldFieldLabel = "Link to Page");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DataEngine.addRepeatableField(fieldLabel = "Link to Page");
+
+		DERenderer.inputDataInLinkToPageField(
+			index = "1",
+			linkToPageContent = "Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
+
+		DERenderer.inputDataInLinkToPageField(
+			index = "2",
+			linkToPageContent = "Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertContentInLinktoPageField(
+			index = "1",
+			linkToPageContent = "Public Pages > Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
+
+		DERenderer.assertContentInLinktoPageField(
+			index = "2",
+			linkToPageContent = "Public Pages > Test Page Name",
+			linkToPageFieldLabel = "Link to Page");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-70110. This test verifies that the Link to Page persists"
 	@priority = "5"
 	test CanInputLink {
 		JSONLayout.addPublicLayout(
@@ -204,7 +245,7 @@ definition {
 			linkToPageFieldLabel = "Link to Page");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-70110. This test verifies that is not possible to publish the Web Content with a required field blank"
 	@priority = "4"
 	test CanNotPublishBlankRequiredField {
 		NavItem.gotoStructures();
@@ -230,7 +271,7 @@ definition {
 		FormViewBuilder.validateObjectLabelOptionTextIsShown(text = "This field is required.");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-70110. This test verifies that is possible to remove a duplicated field (repeatable)"
 	@priority = "4"
 	test CanRemoveDuplicatedField {
 		NavItem.gotoStructures();


### PR DESCRIPTION
- LRQA-70110 Create test stubs
- LRQA-70110 Create inputDataInLinkToPageField, assertLinktoPageIsClear, assertContentInLinktoPageField and assertContent macros
- LRQA-70110 Add CanInputLink test
- LRQA-70110 Add CanNotPublishBlankRequiredField test
- LRQA-70110 Add CanRemoveDuplicatedField test
- LRQA-70110 Add CanClearInput test
- LRQA-70110 Add CanInputDataOnDuplicatedField test
