### PR TITLE
LRQA 69427

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -94,6 +94,18 @@ definition {
 			value1 = "${value}");
 	}
 
+	macro assertDataInRichTextField {
+		DERenderer.selectCKEditorByIndex(
+			fieldLabel = "${fieldLabel}",
+			index = "${index}");
+
+		AssertTextEquals(
+			locator1 = "CKEditor#BODY",
+			value1 = "${content}");
+
+		SelectFrame(value1 = "relative=top");
+	}
+
 	macro assertDataInSelectFromListField {
 		if (!(isSet(index))) {
 			var index = "1";
@@ -388,6 +400,18 @@ definition {
 			value1 = "${value}");
 	}
 
+	macro inputDataInRichTextField {
+		DERenderer.selectCKEditorByIndex(
+			fieldLabel = "${fieldLabel}",
+			index = "${index}");
+
+		Type(
+			locator1 = "CKEditor#BODY",
+			value1 = "${content}");
+
+		SelectFrame(value1 = "relative=top");
+	}
+
 	macro inputDataInSelectFromListField {
 		if (!(isSet(index))) {
 			var index = "1";
@@ -515,6 +539,17 @@ definition {
 			index = "${index}",
 			key_fieldLabel = "${fieldLabel}",
 			locator1 = "DataEngineRenderer#REPEATABLE_FIELD_DELETE_BUTTON_INDEXED");
+	}
+
+	macro selectCKEditorByIndex {
+		if (!(isSet(index))) {
+			var index = "1";
+		}
+
+		SelectFrame.selectFrameNoLoading(
+			index = "${index}",
+			key_fieldLabel = "${fieldLabel}",
+			locator1 = "CKEditor#ANY_BODY_FIELD_IFRAME_WEB_CONTENT_ARTICLE");
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -1,5 +1,13 @@
 definition {
 
+	macro addSourceContentonRichText {
+		Click(locator1 = "CKEditor#TOOLBAR_SOURCE_BUTTON");
+
+		Type.typeCodeMirrorEditorNoError(
+			locator1 = "CKEditor#BODY_FIELD_SOURCE_ON",
+			value1 = "${content}");
+	}
+
 	macro assertDataInColorField {
 		if (!(isSet(index))) {
 			var index = "1";
@@ -229,6 +237,14 @@ definition {
 			key_buttonName = "Clear",
 			key_fieldLabel = "${fieldLabel}",
 			locator1 = "DataEngineRenderer#FIELD_BUTTON_INDEXED");
+	}
+
+	macro clickOnPreviewSourceContent {
+		Click(locator1 = "CKEditor#TOOLBAR_PREVIEW_BUTTON");
+
+		AssertTextEquals.assertPartialText(
+			locator1 = "CKEditor#SOURCE_CODE_DIALOG",
+			value1 = "${content}");
 	}
 
 	macro inputDataInColorField {

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -1,11 +1,19 @@
 definition {
 
+	macro addBoldContentonRichText {
+		Click(locator1 = "DataEngineRenderer#TOOLBAR_BOLD_BUTTON");
+	}
+
 	macro addSourceContentonRichText {
 		Click(locator1 = "CKEditor#TOOLBAR_SOURCE_BUTTON");
 
 		Type.typeCodeMirrorEditorNoError(
 			locator1 = "CKEditor#BODY_FIELD_SOURCE_ON",
 			value1 = "${content}");
+	}
+
+	macro assertBoldContentonRichText {
+		AssertElementPresent(locator1 = "DataEngineRenderer#TOOLBAR_BOLD_BUTTON_ON");
 	}
 
 	macro assertDataInColorField {

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
@@ -76,6 +76,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TOOLBAR_BOLD_BUTTON</td>
+	<td>//a[contains(@class,'cke_button') and contains(@class,'bold')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TOOLBAR_BOLD_BUTTON_ON</td>
+	<td>//a[contains(@class,'cke_button_on') and contains(@class,'bold')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>IMAGE_DESCRIPTION_INDEXED</td>
 	<td>xpath=(//label[normalize-space(text())='${key_fieldLabel}']/following-sibling::div[contains(@class,'form-group')]//input[contains(@name,'description')])[${index}]</td>
 	<td></td>

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -81,12 +81,27 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "5"
 	test CanBeStyled {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DataEngine.addField(
+			fieldFieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.addBoldContentonRichText();
+
+		DERenderer.assertDataInColorField();
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -90,12 +90,27 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "4"
 	test CanClickOnPreview {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DataEngine.addField(
+			fieldFieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.addSourceContentonRichText(content = "Rich Text");
+
+		DERenderer.clickOnPreviewSourceContent(content = "Rich Text");
 	}
 
 	@description = "This is a test for LRQA-68646. This test verifies that Label and Help text can be edited"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -80,6 +80,24 @@ definition {
 			fieldName = "Rich Text");
 	}
 
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanBeStyled {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanClickOnPreview {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
 	@description = "This is a test for LRQA-68646. This test verifies that Label and Help text can be edited"
 	@priority = "5"
 	test CanEditLabelAndHelpText {
@@ -115,6 +133,51 @@ definition {
 			fieldFieldLabel = "Rich Text Edited",
 			fieldHelp = "Help Text Edited",
 			fieldName = "Rich Text");
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanInputData {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanInputDataFromSourceOption {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanInputDataOnDuplicatedField {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanNotPublishBlankRequiredField {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanRemoveDuplicatedField {
+
+		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+
 	}
 
 	@description = "This is a test for LRQA-68646. This test verifies that Default Searchable property is Disable when System Setting is left unchecked"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -80,7 +80,7 @@ definition {
 			fieldName = "Rich Text");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-69427. This test verifies that is possible to apply styles to the data on the Rich Text field"
 	@priority = "5"
 	test CanBeStyled {
 		NavItem.gotoStructures();
@@ -104,7 +104,7 @@ definition {
 		DERenderer.assertDataInColorField();
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-69427. This test verifies that upon clicking on the Preview Icon from the Source option, a modal is displayed"
 	@priority = "4"
 	test CanClickOnPreview {
 		NavItem.gotoStructures();
@@ -197,7 +197,7 @@ definition {
 			fieldLabel = "Rich Text");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "This is a test for LRQA-69427. This test verifies that data inputted on the RIch Text from the Source option persists"
 	@priority = "5"
 	test CanInputDataFromSourceOption {
 		NavItem.gotoStructures();

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -135,13 +135,36 @@ definition {
 			fieldName = "Rich Text");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "This is a test for LRQA-69427. This test verifies that data inputted on the Rich Text field persists."
 	@priority = "5"
 	test CanInputData {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.inputDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text");
 	}
 
 	@description = "This is a stubbed description"
@@ -153,31 +176,116 @@ definition {
 
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "This is a test for LRQA-69427. This test verifies that upon duplicating a repeatable field, inputted data on both fields persists"
 	@priority = "5"
 	test CanInputDataOnDuplicatedField {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		DataEngine.toggleFieldRepeatable(fieldFieldLabel = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DataEngine.addRepeatableField(fieldLabel = "Rich Text");
+
+		DERenderer.inputDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text",
+			index = "1");
+
+		DERenderer.inputDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text",
+			index = "2");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text",
+			index = "1");
+
+		DERenderer.assertDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text",
+			index = "2");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "This is a test for LRQA-69427. This test verifies that is not possible to publish the Web Content with a required field blank	"
 	@priority = "4"
 	test CanNotPublishBlankRequiredField {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldFieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		DataEngine.editFieldRequired(fieldFieldLabel = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		Navigator.gotoNavTab(navTab = "Web Content");
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		Button.clickPublish();
+
+		FormViewBuilder.validateObjectLabelOptionTextIsShown(text = "This field is required.");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "This is a test for LRQA-69427. This test verifies that is possible to remove a duplicated field (repeatable)"
 	@priority = "4"
 	test CanRemoveDuplicatedField {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DEBuilder.addField(
+			fieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		DataEngine.toggleFieldRepeatable(fieldFieldLabel = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DataEngine.addRepeatableField(fieldLabel = "Rich Text");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.removeRepeatableField(fieldLabel = "Rich Text");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DEBuilder.assertFieldNotPresent(
+			fieldLabel = "Rich Text",
+			index = "2");
 	}
 
 	@description = "This is a test for LRQA-68646. This test verifies that Default Searchable property is Disable when System Setting is left unchecked"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DERichTextField.testcase
@@ -198,12 +198,33 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "5"
 	test CanInputDataFromSourceOption {
+		NavItem.gotoStructures();
 
-		// TODO LRQA-69427 Refactor of Renderer Rich Text Field
+		WebContentStructures.addCP(structureName = "WC Structure Title");
 
+		DataEngine.addField(
+			fieldFieldLabel = "Rich Text",
+			fieldName = "Rich Text");
+
+		WebContentStructures.saveCP();
+
+		NavItem.gotoWebContent();
+
+		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Title");
+
+		PortletEntry.inputTitle(title = "Web Content Title");
+
+		DERenderer.addSourceContentonRichText(content = "Rich Text");
+
+		Button.clickPublish();
+
+		WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
+
+		DERenderer.assertDataInRichTextField(
+			content = "Rich Text",
+			fieldLabel = "Rich Text");
 	}
 
 	@description = "This is a test for LRQA-69427. This test verifies that upon duplicating a repeatable field, inputted data on both fields persists"


### PR DESCRIPTION
- LRQA-69427 Add test stubs
- LRQA-69427 Create assertDataInRichTextField and inputDataInRichTextField macros
- LRQA-69427 Add tests CanRemoveDuplicatedField, CanNotPublishBlankRequiredField, CanInputDataOnDuplicatedField, CanInputData
- LRQA-69427 Create addSourceContentonRichText and clickOnPreviewSourceContent macros
- LRQA-69427 Add CanClickOnPreview test
- LRQA-69427 Create TOOLBAR_BOLD_BUTTON and TOOLBAR_BOLD_BUTTON_ON path
- LRQA-69427 Add addBoldContentonRichText and assertDataInColorField macros
- LRQA-69427 Add CanBeStyled test
- LRQA-69427 Add CanInputDataFromSourceOption test
